### PR TITLE
Corrected repository URL and other references to angular-seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,27 +42,26 @@ The seed app doesn't do much, just shows how to wire two controllers and views t
 
 ## Getting Started
 
-To get you started you can simply clone the angular-seed repository and install the dependencies:
+To get you started you can simply clone the angular-sensible-seed repository and install the dependencies:
 
 ### Prerequisites
   * git [http://git-scm.com/](http://git-scm.com/)
   * npm [http://nodejs.org/](http://nodejs.org/)
 
-### Clone angular-seed
+### Clone angular-sensible-seed
 
-Clone the angular-seed repository using [git][git]:
+Clone the angular-sensible-seed repository using [git][git]:
 
 ```
-git clone https://github.com/angular/angular-seed.git
-cd angular-seed
+git clone https://github.com/okigan/angular-sensible-seed.git
+cd angular-sensible-seed
 npm install
-bower install
 ```
 
 ### Install Dependencies
 
 Note that the `bower_components` folder would normally be installed in the root folder but
-angular-seed changes this location through the `.bowerrc` file.  Putting it in the app folder makes
+angular-sensible-seed changes this location through the `.bowerrc` file.  Putting it in the app folder makes
 it easier to serve the files by a webserver.*
 
 ### Run the Application
@@ -97,13 +96,13 @@ Now browse to the app at `http://localhost:8000/app/index.html`.
 
 ## Testing
 
-There are two kinds of tests in the angular-seed application: 
+There are two kinds of tests in the angular-sensible-seed application: 
   * Unit tests and 
   * End to End tests.
 
 ### Running Unit Tests
 
-The angular-seed app comes preconfigured with unit tests. These are written in
+The angular-sensible-seed app comes preconfigured with unit tests. These are written in
 [Jasmine][jasmine], which we run with the [Karma Test Runner][karma]. We provide a Karma
 configuration file to run them.
 
@@ -132,7 +131,7 @@ npm run test-single-run
 
 ### End to end testing
 
-The angular-seed app comes with end-to-end tests, again written in [Jasmine][jasmine]. These tests
+The angular-sensible-seed app comes with end-to-end tests, again written in [Jasmine][jasmine]. These tests
 are run with the [Protractor][protractor] End-to-End test runner.  It uses native events and has
 special features for Angular applications.
 
@@ -147,7 +146,7 @@ can interact with it.
 npm start
 ```
 
-In addition, since Protractor is built upon WebDriver we need to install this.  The angular-seed
+In addition, since Protractor is built upon WebDriver we need to install this.  The angular-sensible-seed
 project comes with a predefined script to do this:
 
 ```
@@ -190,7 +189,7 @@ etc to function properly when an html page is opened via `file://` scheme instea
 
 ### Running the App during Development
 
-The angular-seed project comes preconfigured with a local development webserver.  It is a node.js
+The angular-sensible-seed project comes preconfigured with a local development webserver.  It is a node.js
 tool called [http-server][http-server].  You can start this webserver with `npm start` but you may choose to
 install the tool globally:
 
@@ -229,7 +228,7 @@ reverse-proxying the backend server(s) and webserver(s).
 ### Travis CI
 
 [Travis CI][travis] is a continuous integration service, which can monitor GitHub for new commits
-to your repository and execute scripts such as building the app or running tests. The angular-seed
+to your repository and execute scripts such as building the app or running tests. The angular-sensible-seed
 project contains a Travis configuration file, `.travis.yml`, which will cause Travis to run your
 tests when you push to GitHub.
 


### PR DESCRIPTION
Basically I just replaced every remaining instance of `angular-seed` with `angular-sensible-seed` and corrected the git repository URL from  `angular/angular-seed` to `okigan/angular-sensible-seed`
I did this because when I first found this seed, I cloned it using the instructions in the README.MD, but then found that I did not have `angular-sensible-seed` like I intended, but rather the standard `angular-seed`, which is not what I wanted.
